### PR TITLE
RobotError: Fix __repr__()/__str__() issue.

### DIFF
--- a/hetzner/__init__.py
+++ b/hetzner/__init__.py
@@ -1,13 +1,8 @@
 class RobotError(Exception):
     def __init__(self, message, status=None):
-        self.message = message
+        formattedMessage = message if status is None else "{0} ({1})".format(message, status)
+        super(Exception, self).__init__(formattedMessage)
         self.status = status
-
-    def __str__(self):
-        if self.status is None:
-            return self.message
-        else:
-            return "{0} ({1})".format(self.message, self.status)
 
 
 class ManualReboot(Exception):

--- a/hetzner/robot.py
+++ b/hetzner/robot.py
@@ -86,7 +86,7 @@ class RobotWebInterface(object):
         if self.user.startswith("#ws+"):
             raise WebRobotError("The user {0} is a dedicated web service user "
                                 "and cannot be used for scraping the web user "
-                                "interface.")
+                                "interface.".format(self.user))
 
         # This is primarily for getting a first session cookie.
         response = self.request('/login', xhr=False)


### PR DESCRIPTION
Commit 280f8d31 already tried to improve this, but the reliable way
to render an exception message is to pass it as the first argument
to the `Exception` superclass constructor; see:
https://stackoverflow.com/questions/1319615/proper-way-to-declare-custom-exceptions-in-modern-python

This guarantees that both `repr()` and `str()` are set as expected.

Until now, for example, `repr()` did not actually render the exception
name "RobotError", which was confusing, as all other Python exceptions
do that, and the docs say that it should.
Similarly, the fix from 280f8d31 actually broke the `str()`, which
until now was just `RobotError()`.
This commit fixes both these issues.