### PR TITLE
Failover

### DIFF
--- a/hetzner/failover.py
+++ b/hetzner/failover.py
@@ -2,6 +2,7 @@ from hetzner import RobotError
 
 __all__ = ['Failover', 'FailoverManager']
 
+
 class Failover(object):
     ip = None
     server_ip = None
@@ -35,17 +36,20 @@ class FailoverManager(object):
     def set(self, ip, new_destination):
         failovers = self.list()
         if ip not in failovers.keys():
-            raise RobotError("Invalid IP address '%s'. Failover IP addresses are %s" % (ip, failovers.keys()))
+            raise RobotError(
+                "Invalid IP address '%s'. Failover IP addresses are %s"
+                % (ip, failovers.keys()))
         failover = failovers.get(ip)
         if new_destination == failover.active_server_ip:
-            raise RobotError("%s is already the active destination of failover IP %s" % (new_destination, ip))
+            raise RobotError(
+                "%s is already the active destination of failover IP %s"
+                % (new_destination, ip))
         available_dests = [s.ip for s in list(self.servers)]
         if new_destination not in available_dests:
-            raise RobotError("Invalid destination '%s'. The destination is not in your server list: %s" %
-                             (new_destination, available_dests))
-        result = self.conn.post('/failover/%s' % ip, {'active_server_ip': new_destination})
+            raise RobotError(
+                "Invalid destination '%s'. "
+                "The destination is not in your server list: %s"
+                % (new_destination, available_dests))
+        result = self.conn.post('/failover/%s'
+                                % ip, {'active_server_ip': new_destination})
         return Failover(result.get('failover'))
-
-
-
-

--- a/hetzner/failover.py
+++ b/hetzner/failover.py
@@ -1,0 +1,51 @@
+from hetzner import RobotError
+
+__all__ = ['Failover', 'FailoverManager']
+
+class Failover(object):
+    ip = None
+    server_ip = None
+    server_number = None
+    active_server_ip = None
+
+    def __repr__(self):
+        return "%s (destination: %s, booked on %s (%s))" % (
+            self.ip, self.active_server_ip, self.server_number, self.server_ip)
+
+    def __init__(self, data):
+        for attr, value in data.items():
+            if hasattr(self, attr):
+                setattr(self, attr, value)
+
+
+class FailoverManager(object):
+
+    def __init__(self, conn, servers):
+        self.conn = conn
+        self.servers = servers
+
+    def list(self):
+        failovers = {}
+        ips = self.conn.get('/failover')
+        for ip in ips:
+            failover = Failover(ip.get('failover'))
+            failovers[failover.ip] = failover
+        return failovers
+
+    def set(self, ip, new_destination):
+        failovers = self.list()
+        if ip not in failovers.keys():
+            raise RobotError("Invalid IP address '%s'. Failover IP addresses are %s" % (ip, failovers.keys()))
+        failover = failovers.get(ip)
+        if new_destination == failover.active_server_ip:
+            raise RobotError("%s is already the active destination of failover IP %s" % (new_destination, ip))
+        available_dests = [s.ip for s in list(self.servers)]
+        if new_destination not in available_dests:
+            raise RobotError("Invalid destination '%s'. The destination is not in your server list: %s" %
+                             (new_destination, available_dests))
+        result = self.conn.post('/failover/%s' % ip, {'active_server_ip': new_destination})
+        return Failover(result.get('failover'))
+
+
+
+

--- a/hetzner/robot.py
+++ b/hetzner/robot.py
@@ -16,6 +16,7 @@ except ImportError:
 from hetzner import WebRobotError, RobotError
 from hetzner.server import Server
 from hetzner.rdns import ReverseDNSManager
+from hetzner.failover import FailoverManager
 from hetzner.util.http import ValidatedHTTPSConnection
 
 ROBOT_HOST = "robot-ws.your-server.de"
@@ -267,3 +268,4 @@ class Robot(object):
         self.conn = RobotConnection(user, passwd)
         self.servers = ServerManager(self.conn)
         self.rdns = ReverseDNSManager(self.conn)
+        self.failover = FailoverManager(self.conn, self.servers)

--- a/hetznerctl
+++ b/hetznerctl
@@ -231,6 +231,40 @@ class ReverseDNS(SubCommand):
             else:
                 self.putline("{0} -> {1}".format(rdns.ip, rdns.ptr))
 
+class Failover(SubCommand):
+    command = 'failover'
+    description = 'List and set failover IP addresses'
+
+    option_list = [
+        make_option('-s', '--set', dest='setfailover', action='store_true',
+                    default=False, help="Assign failover IP address to server"),
+        make_option('ip', nargs='?', default=None,
+                    help="Failover IP address to assign"),
+        make_option('destination', nargs='?', default=None,
+                    help="IP address of new failover destination")
+    ]
+
+    def execute(self, robot, parser, args):
+        if args.setfailover:
+            errs = []
+            if not args.ip:
+                errs.append("Error: you need to set the failover IP you want to assign. Option 'ip'")
+            if not args.destination:
+                errs.append("Error: you need to set the new destination of the failover IP. Option 'dest'")
+            if len(errs) > 0:
+                for err in errs:
+                    self.putline(err)
+            else:
+                failover = robot.failover.set(args.ip, args.destination)
+                self.putline("Failover IP successfully assigned to new destination")
+                self.putline(str(failover))
+        else:
+            failovers = robot.failover.list()
+            if len(failovers) > 0:
+                self.putline("Found %s failover IPs" % len(failovers))
+            for failover in failovers.values():
+                self.putline(str(failover))
+
 
 class Admin(SubCommand):
     command = 'admin'
@@ -313,6 +347,7 @@ def main():
         ShowServer,
         ReverseDNS,
         Admin,
+        Failover,
     ]
 
     common_parser = argparse.ArgumentParser(


### PR DESCRIPTION
Hi,

thanks for creating hetznerctl. I found it when I was looking for libraries to access  Hetzner's Robot API. The feature I needed was changing failover IP addresses. In this patch I added a new Subcommand 'failover' with two options:
- list all failover IP addresses for an account
- assign a failover IP address to a new destination

Hope you like it.

Greetings,
Peter


